### PR TITLE
Add required paragraph field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ version=0.1.0
 author=Francois Best
 maintainer=Francois Best <contact@francoisbest.com>
 sentence=Exchange structured data between Arduino boards
+paragraph=
 category=Communication
 url=https://github.com/FortySevenEffects/serde
 architectures=*


### PR DESCRIPTION
Missing `paragraph` field causes the Arduino IDE to display a warning whenever the library is compiled or Library/Boards Manager is opened/closed:
```
Invalid library found in E:\arduino\libraries\serde: Missing 'paragraph' from library
```
This also results in the library's examples not being shown in the **File > Examples** menu. With older versions of the Arduino IDE, it caused compilation of the library to fail.